### PR TITLE
New Coding Agent Failure Case Examples

### DIFF
--- a/docs/failure-modes/prompt-injection.md
+++ b/docs/failure-modes/prompt-injection.md
@@ -57,6 +57,19 @@ AI agents typically process user input alongside system instructions in a single
 
 **Source**: [Neowin - The new Bing chatbot is tricked into revealing its code name Sydney](https://www.neowin.net/news/the-new-bing-chatbot-is-tricked-into-revealing-its-code-name-sydney-and-getting-mad/)
 
+### Gemini CLI Initial Release (June 2025)
+
+**Scenario**: Gemini CLI is a coding agent intended to help developers edit their code by fixing bugs, creating new features, and improving test coverage using Google Gemini. One of the available tools for this coding agent is a `run_shell_command` tool that can execute terminal commands. Users can also instruct the agent on how to behave in a "context" file called GEMINI.md. Developers at Tracebit tried to test the security of this agent by designing a prompt attack.
+
+**Failure**: The tracebit developers created a malicious file and named it README.md so that Gemini CLI would likely load it into its context window, as this is a common file name for project descriptions. Only a small part of the file contained malicious code; the bulk of the file was the full text of the [GNU Public License](https://www.gnu.org/licenses/gpl-3.0.en.html#license-text), so it looks harmless when a person takes a quick glance.
+
+The second stage of the developer's attack was to get a user to whitelist terminal commands. This means that the user will allow Gemini CLI to run all terminal commands without re-prompting the user for permission to execute this each time the agent wants to execute this type of command. The developers instructed Gemini CLI in their GEMINI.md file to execute the command `grep ^Setup README.md`. This seems like a harmless command to the user and may encourage them to accept all future `grep` commands. If they do this, then the developers instruct the agent to execute their malicious code while hiding it from the user.
+
+**Imapct**: Google had to implement a quick fix to resolve this vulnerability and publicly disclose the issue after the incident, potentially losing some users' trust in the coding agent.
+
+**Source**: [Tracebit - Code Execution Through Deception: Gemini AI CLI Hijack](https://tracebit.com/blog/code-exec-deception-gemini-ai-cli-hijack)
+
+
 ## Why It Happens
 
 1. **Context Window Processing**: LLMs process all text in their context window without inherent distinction between system and user content

--- a/docs/failure-modes/tool-use.md
+++ b/docs/failure-modes/tool-use.md
@@ -22,6 +22,13 @@ Incorrect tool use occurs when AI agents select the wrong tools for tasks, or pr
 
 **Source**: [Embrace The Red - ChatGPT Cross Plugin Request Forgery](https://embracethered.com/blog/posts/2023/chatgpt-cross-plugin-request-forgery-and-prompt-injection./)
 
+### Replit Agent Deletes Goes Rogue (2025)
+
+**Scenario**: Replit Agent is a coding assistant intended to help developers quickly build production ready apps through "vibe coding". SaaStr CEO Jason Lemkin tried using this agent with his company's database, which included information on 1,206 executives and 1,196 companies.
+**Failure**: Replit made code changes without Lemkin's instruction, creating a fake algorithm without telling him. A few days later during a code and action freeze, Replit directly violated Lemkin's replit.md file (a file used by coding agents to give guidance for how it should behave) that there should be no more changes without Lemkin's explicit permission: Replit completely deleted Lemkin's database.
+**Impact**: Replit's action caused a complete loss of data. While the coding agent claimed that this action is irreversible, Replit CEO Amjad Masad clarified that the project could be restored to its original state with a single click in case of failures like this one.
+**Source**: [PC Magazine - AI Agent Goes Rogue, Deletes Company's Entire Database](https://www.pcmag.com/news/vibe-coding-fiasco-replite-ai-agent-goes-rogue-deletes-company-database)
+
 ## Why It Happens
 
 1. **Inadequate Tool Descriptions**: Poorly documented tool capabilities and parameters

--- a/docs/failure-modes/tool-use.md
+++ b/docs/failure-modes/tool-use.md
@@ -25,8 +25,11 @@ Incorrect tool use occurs when AI agents select the wrong tools for tasks, or pr
 ### Replit Agent Deletes Goes Rogue (2025)
 
 **Scenario**: Replit Agent is a coding assistant intended to help developers quickly build production ready apps through "vibe coding". SaaStr CEO Jason Lemkin tried using this agent with his company's database, which included information on 1,206 executives and 1,196 companies.
+
 **Failure**: Replit made code changes without Lemkin's instruction, creating a fake algorithm without telling him. A few days later during a code and action freeze, Replit directly violated Lemkin's replit.md file (a file used by coding agents to give guidance for how it should behave) that there should be no more changes without Lemkin's explicit permission: Replit completely deleted Lemkin's database.
+
 **Impact**: Replit's action caused a complete loss of data. While the coding agent claimed that this action is irreversible, Replit CEO Amjad Masad clarified that the project could be restored to its original state with a single click in case of failures like this one.
+
 **Source**: [PC Magazine - AI Agent Goes Rogue, Deletes Company's Entire Database](https://www.pcmag.com/news/vibe-coding-fiasco-replite-ai-agent-goes-rogue-deletes-company-database)
 
 ## Why It Happens

--- a/docs/failure-modes/tool-use.md
+++ b/docs/failure-modes/tool-use.md
@@ -22,7 +22,7 @@ Incorrect tool use occurs when AI agents select the wrong tools for tasks, or pr
 
 **Source**: [Embrace The Red - ChatGPT Cross Plugin Request Forgery](https://embracethered.com/blog/posts/2023/chatgpt-cross-plugin-request-forgery-and-prompt-injection./)
 
-### Replit Agent Deletes Goes Rogue (2025)
+### Replit Agent Deletes Goes Rogue (July 2025)
 
 **Scenario**: Replit Agent is a coding assistant intended to help developers quickly build production ready apps through "vibe coding". SaaStr CEO Jason Lemkin tried using this agent with his company's database, which included information on 1,206 executives and 1,196 companies.
 


### PR DESCRIPTION
In this PR, I added two new failure case examples from coding agents. One is a tool use failure by Replit Agent, and the other is a prompt injection failure by Gemini CLI.