### PR TITLE
Add APort as an agent failure mitigation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ AI agents fail in predictable ways. This repository documents known failure mode
 
 ### External Resources
 - [Specification Gaming](https://vkrakovna.wordpress.com/2018/04/02/specification-gaming-examples-in-ai/) - Collection of reward hacking examples.
+- [APort Integrations](https://github.com/aporthq/aport-integrations) - Open-source middleware examples for agent identity verification and policy-enforced tool calls, useful for mitigating prompt injection and incorrect tool use.
 
 ### Related Awesome Lists
 - [Awesome LLM](https://github.com/Hannibal046/Awesome-LLM) - Large Language Models.

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -13,6 +13,9 @@ This directory contains tools specifically designed to detect, monitor, and miti
 - **[Phoenix by Arize](phoenix-arize.md)** - Built-in agent evaluation tools
 - **[TruLens](trulens.md)** - LLM application evaluation and tracking
 
+### Tool-Use Safety & Authorization
+- **[APort Integrations](aport-integrations.md)** - Agent identity verification and policy enforcement before tool calls execute
+
 ## 🚀 Quick Start Guide
 
 ### For Tool Hallucination
@@ -39,6 +42,7 @@ This directory contains tools specifically designed to detect, monitor, and miti
 | LangSmith | All modes | SaaS | Paid | Yes |
 | Phoenix | All modes | Self-hosted/Cloud | Free/Paid | Yes |
 | TruLens | All modes | Self-hosted/Enterprise | Free/Paid | No |
+| APort Integrations | Prompt Injection, Incorrect Tool Use | Self-hosted | Free | Yes |
 
 ## 🛠️ Implementation Examples
 

--- a/docs/tools/aport-integrations.md
+++ b/docs/tools/aport-integrations.md
@@ -1,0 +1,29 @@
+# APort Integrations
+
+## Overview
+
+APort Integrations is an open-source collection of middleware and framework examples for agent identity verification and policy enforcement before AI agents invoke external tools. It is most useful when a system needs a deterministic control point outside the prompt, such as checking who the agent is, what tool it is about to call, and whether the action should be allowed before execution.
+
+## Key Features
+
+- **Pre-action policy checks**: Enforces authorization decisions before tool calls execute, reducing the blast radius of prompt injection and confused-deputy failures.
+- **Agent identity verification**: Gives tool gateways a way to distinguish an authorized agent from a generic model response or untrusted workflow.
+- **Framework integrations**: Includes examples for Express, FastAPI, LangChain, Shopify, MCP bridges, and other common agent application surfaces.
+- **Auditable guardrail placement**: Moves sensitive allow/deny decisions into middleware where they can be logged, tested, and reviewed.
+- **Tool-use safety**: Helps prevent incorrect or over-broad tool invocation by requiring explicit policy approval for high-risk actions.
+
+## Failure Modes Addressed
+
+- **Prompt Injection**: Injected instructions may influence the model, but the tool call still has to pass an external policy check.
+- **Incorrect Tool Use**: Agents can be blocked from using disallowed tools or dangerous parameters even when the generated plan is wrong.
+- **Verification & Termination Failures**: Middleware logs and policy outcomes provide evidence for whether high-risk steps were attempted, allowed, or denied.
+
+## Pricing
+
+- **Open Source**: Free to use from the public GitHub repository.
+- **Self-Hosted**: Deploy the middleware patterns in your own application or gateway.
+
+## Additional Resources
+
+- **GitHub Repository**: [https://github.com/aporthq/aport-integrations](https://github.com/aporthq/aport-integrations)
+- **Use Case**: Agent identity verification and runtime policy enforcement for AI-agent tool calls.


### PR DESCRIPTION
## Summary
- Add APort Integrations as a tool-use safety and authorization resource.
- Document how it maps to prompt injection, incorrect tool use, and verification failure modes.
- Link the tool from the top-level external resources and tools index.

## Verification
- `git diff --check --cached`
- `curl.exe -I -L --max-time 20 https://github.com/aporthq/aport-integrations` returned HTTP 200.

Bounty issue: https://github.com/aporthq/aport-integrations/issues/19

Preferred payout: PayPal https://paypal.me/Jeremytsangchina
Crypto fallback: USDT TRC20 TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y