### PR TITLE
Add agent-qa outcome-verification tool

### DIFF
--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -9,6 +9,7 @@ This directory contains tools specifically designed to detect, monitor, and miti
 - **[Vectara VHC](vectara-vhc.md)** - Hallucination correction system
 
 ### Agent Monitoring & Evaluation
+- **[agent-qa](agent-qa.md)** - Outcome-focused regression testing and evidence capture for coding-agent changes
 - **[LangSmith](langsmith.md)** - Comprehensive LLM observability platform
 - **[Phoenix by Arize](phoenix-arize.md)** - Built-in agent evaluation tools
 - **[TruLens](trulens.md)** - LLM application evaluation and tracking
@@ -29,11 +30,13 @@ This directory contains tools specifically designed to detect, monitor, and miti
 1. **Intent Tracking**: Monitor goal alignment with Phoenix or LangSmith
 2. **Evaluation**: Deploy TruLens evaluations for intent consistency
 3. **Testing**: Create custom evaluation metrics for goal alignment
+4. **Outcome Verification**: Use agent-qa to replay critical web/mobile flows and retain evidence across coding-agent changes
 
 ## 📊 Tool Comparison Matrix
 
 | Tool | Failure Modes | Deployment | Cost | Real-time |
 |------|---------------|------------|------|-----------|
+| agent-qa | Goal/verification failures in software changes | Self-hosted | No package fee | During test runs |
 | Vectara HHEM | Tool/Response Hallucination | Self-hosted | Free | Yes |
 | Vectara VHC | Response Hallucination | Vectara Platform | Enterprise | Yes |
 | LangSmith | All modes | SaaS | Paid | Yes |
@@ -61,6 +64,7 @@ Each tool documentation includes specific integration examples:
 - **LangChain**: See individual tool docs for LangChain setup examples
 - **LlamaIndex**: TruLens and Phoenix provide LlamaIndex integration guides
 - **Custom Agents**: Phoenix and LangSmith offer generic integration patterns
+- **Coding Agents**: agent-qa exposes QA workflows through MCP and Agent Skills
 - **OpenTelemetry**: Phoenix and TruLens support standard OTEL tracing
 
 ## 🤝 Contributing New Tools

--- a/docs/tools/agent-qa.md
+++ b/docs/tools/agent-qa.md
@@ -1,0 +1,44 @@
+# agent-qa
+
+## Overview
+
+agent-qa is a source-available QA harness for natural-language web and mobile regression tests. It is aimed at verifying the software outcomes produced by coding agents: tests run against the application, execution evidence is retained, and lessons from past runs can inform later executions.
+
+This is outcome-focused testing rather than general-purpose LLM tracing. It can help expose cases where a coding agent stops with a plausible implementation even though a user flow is still broken.
+
+## Key Features
+
+- **Natural-Language Tests**: Defines browser and mobile actions and assertions in human-readable test files
+- **Web and Mobile Runners**: Uses Playwright for web flows and Appium for mobile flows
+- **Persistent Execution Memory**: Carries product, suite, test, and healed-step observations into later runs
+- **Self-Healing Execution**: Re-observes the interface and tries another path when an individual interaction fails
+- **Reviewable Evidence**: Retains test definitions, run artifacts, and execution context for failure triage
+- **Agent Interfaces**: Provides a CLI, MCP server, and three Agent Skills alongside a dashboard
+- **Model Choice**: Supports OpenAI- and Anthropic-compatible endpoints, Gemini, and local models
+
+## Failure Modes Addressed
+
+- **Verification and Termination**: Replays acceptance flows before an agent or team treats a change as complete
+- **Goal Misinterpretation**: Encodes expected user-visible outcomes independently from the implementation produced by a coding agent
+- **Regression Accumulation**: Re-runs durable workflows after later changes and retains evidence from prior execution
+
+## Limitations and Safety
+
+- agent-qa is not an LLM hallucination detector or a full tracing platform for arbitrary agent internals.
+- Test reliability still depends on the environment, model, assertions, and quality of the application state provided to a run.
+- Browser and mobile tests may perform real write actions. Use scoped test accounts and disposable environments for destructive or externally visible flows.
+- Docker is required only when using the optional sandboxed hook runtime.
+
+## Pricing and License
+
+- **Package**: Published on npm with no package fee documented
+- **Operating Costs**: Model-provider, device, and infrastructure costs depend on the chosen setup
+- **License**: FSL-1.1-ALv2, converting to Apache-2.0 after two years
+
+## Additional Resources
+
+- **GitHub Repository**: [vostride/agent-qa](https://github.com/vostride/agent-qa)
+- **Documentation**: [agent-qa docs](https://vostride.com/docs/agent-qa)
+- **Quickstart**: [Installation and first run](https://vostride.com/docs/agent-qa/quickstart)
+- **Agent Skills**: [Source skill pack](https://github.com/vostride/agent-qa/tree/main/skills)
+- **npm Package**: [agent-qa](https://www.npmjs.com/package/agent-qa)


### PR DESCRIPTION
## Summary

Adds agent-qa as an outcome-verification tool for coding-agent changes. The new profile explains how natural-language web/mobile regression tests, persistent execution memory, and retained artifacts can catch verification/termination and goal-misinterpretation failures at the software-behavior layer.

## Scope and limitations

The profile explicitly distinguishes agent-qa from general LLM tracing or hallucination detection. It also records that test reliability depends on environment/model quality and that write-capable browser/mobile flows should use scoped test accounts and disposable environments.

No independent performance benchmark is claimed; the page describes only source-backed capabilities and marks operating costs as setup-dependent.

## Validation

- Added the standard Overview, Key Features, Pricing/License, and Additional Resources sections.
- Mapped the tool to specific failure modes and linked it from the comparison/index page.
- Canonical repository, documentation, quickstart, skills, npm, and license URLs were verified.
- Relative documentation links resolve and `git diff --check` passes.

Project disclosure: this submission is for agent-qa itself. Its current FSL-1.1-ALv2 license converts to Apache-2.0 after two years. The documentation contributed here is original text submitted under this repository's Apache-2.0 contribution terms.
