### PR TITLE
Add YYLO coding-agent evaluation benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ AI agents fail in predictable ways. This repository documents known failure mode
 #### Browser-Agent Evaluation
 - [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) ([paper](https://arxiv.org/abs/2604.08523)) - Live-web benchmark for browser and computer-use agents spanning 283 everyday tasks across 163 websites, with request interception and five execution-evidence layers.
 
+#### Coding-Agent Evaluation
+- [YYLO Benchmark](https://github.com/yylo-dev/yylo-benchmark) - Isolated evaluation layer for task prompts that runs each candidate in a private fresh-repository workspace and evaluates retained evidence with ordered deterministic and/or LLM-judge profiles.
+
 #### Planning & Reasoning
 - [A Survey on Large Language Model Reasoning Failures](https://openreview.net/pdf?id=hsgMn4KBFG) - A comprehensive review that introduces a novel taxonomy of reasoning in LLMs (embodied vs. non-embodied), and spotlights three categories of reasoning.
 


### PR DESCRIPTION
## Summary

- Adds a new `#### Coding-Agent Evaluation` subsection under **📚 Resources → Research Papers**, with one entry for [YYLO Benchmark](https://github.com/yylo-dev/yylo-benchmark).
- +3 lines in `README.md` only, mirroring the shape of the merged ClawBench addition (#47), which introduced `#### Browser-Agent Evaluation` the same way.
- No other files touched.

## Why it belongs here

- The contributing guide's "Build Tools" category explicitly lists **evaluation benchmarks**, and this entry follows the README-Resources route for tools ("link to external GitHub repositories with comprehensive documentation").
- YYLO Benchmark is an open-source (MIT) evaluation layer for task prompts: it normalizes every case into one attempt contract, runs each candidate in a private fresh-repository workspace, and evaluates **retained evidence** with ordered deterministic and/or LLM-judge profiles. Outcome verification against retained evidence is directly relevant to the documented *verification-termination* failure mode (agents reporting completion without verifiable results).
- The entry is a sibling of `#### Browser-Agent Evaluation` (ClawBench): a domain-scoped benchmark subsection for coding agents.

## Quality standards check

- ✅ Publicly accessible: MIT-licensed repo with README, install, usage docs; published as [`@yylo/benchmark`](https://www.npmjs.com/package/@yylo/benchmark).
- ✅ Directly relevant to AI agent failure modes (evaluation/verification of agent task completion).
- ✅ All links tested; descriptive link text; one factual sentence, no promotional language.

## Disclosure

I'm a member of the YYLO team, and this PR was prepared with the help of an AI coding agent following your contributing guide. Happy to adjust the placement, wording, or section framing — or withdraw the entry entirely if the maintainers feel it doesn't meet the bar.
